### PR TITLE
Refactor tests to use pytest parametrization

### DIFF
--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -14,6 +14,7 @@ import tempfile
 from pathlib import Path
 
 import duckdb
+import pytest
 from fastapi.testclient import TestClient
 
 TEMP_DIR = Path(tempfile.mkdtemp(prefix="etymdb-test-"))
@@ -163,15 +164,16 @@ def test_graph_endpoint_returns_nodes_and_edges():
     assert any(node["lexeme"] == "mother" for node in payload["nodes"])
 
 
-def test_graph_endpoint_missing_word():
-    response = client.get("/graph/unknownword")
-    assert response.status_code == 404
-
-
-def test_graph_endpoint_word_without_etymology():
-    """Test that words with no etymology links return 404."""
-    # "loneword" exists in DB but has no links, so it should return 404
-    response = client.get("/graph/loneword")
+@pytest.mark.parametrize(
+    "word",
+    [
+        pytest.param("unknownword", id="missing-word"),
+        pytest.param("loneword", id="no-etymology"),
+    ],
+)
+def test_graph_endpoint_returns_404(word):
+    """Test that graph returns 404 for missing words or words without etymology."""
+    response = client.get(f"/graph/{word}")
     assert response.status_code == 404
 
 


### PR DESCRIPTION
## Summary

Refactor duplicate test cases to use `@pytest.mark.parametrize` for better test visibility and reduced code duplication.

## Changes

- Combined `test_graph_endpoint_missing_word` and `test_graph_endpoint_word_without_etymology` into a single parametrized test
- Added descriptive test IDs (`missing-word`, `no-etymology`) for clear test output
- Added `pytest` import

## Before
```
test_graph_endpoint_missing_word PASSED
test_graph_endpoint_word_without_etymology PASSED
```

## After
```
test_graph_endpoint_returns_404[missing-word] PASSED
test_graph_endpoint_returns_404[no-etymology] PASSED
```

## Test Plan
- [x] All 9 tests pass
- [x] Parametrized tests show descriptive IDs in output

Fixes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)