### PR TITLE
[codex] Make cognates opt-in for etymology graphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ Human-readable history of the Etymology Graph Explorer.
 
 ---
 
+## Unreleased
+
+### Fixed
+- Default graphs now hide cognates and other related-word links so arrows represent direct ancestry. Cognates remain available through an explicit setting and `include_related=true` API parameter.
+
+---
+
 ## v0.11.0 - Bug Fixes and Improvements (2026-01-28)
 
 Small bug fixes and improvements to backend, UI, and documentation.
@@ -399,4 +406,3 @@ Merged the improved backend implementation:
 [EtymDB 2.1](https://github.com/clefourrier/EtymDB) - open etymological database derived from Wiktionary.
 
 > Fourrier & Sagot (2020), "Methodological Aspects of Developing and Managing an Etymological Lexical Resource"
-

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ docker run -p 7860:7860 etymology
 | Endpoint | Description |
 |----------|-------------|
 | `GET /` | Web interface |
-| `GET /graph/{word}` | Etymology graph for a word (JSON) |
+| `GET /graph/{word}` | Etymology graph for a word (JSON); add `include_related=true` to include cognates |
 | `GET /search?q=<query>&limit=<n>` | Search/autocomplete for words |
 | `GET /random` | Random English word |
 | `GET /version` | App version and database stats |

--- a/backend/database.py
+++ b/backend/database.py
@@ -179,7 +179,7 @@ def fetch_etymology(word: str, depth: int = 5, include_related: bool = False) ->
         # Find starting word (prefer English, then most etymology links)
         start = conn.execute(
             load_sql("queries/find_start_word.sql"),
-            [word],
+            [word, include_related],
         ).fetchone()
         if not start:
             return None

--- a/backend/database.py
+++ b/backend/database.py
@@ -166,7 +166,7 @@ def get_db_stats() -> dict:
         return {"words": words, "definitions": definitions}
 
 
-def fetch_etymology(word: str, depth: int = 5) -> dict | None:
+def fetch_etymology(word: str, depth: int = 5, include_related: bool = False) -> dict | None:
     """Return an etymology graph for *word* or ``None`` if absent."""
     if not word:
         return None
@@ -197,7 +197,7 @@ def fetch_etymology(word: str, depth: int = 5) -> dict | None:
             # Track is_compound to style compound edges differently in the UI
             records = conn.execute(
                 load_sql("queries/traverse_etymology.sql"),
-                [start_ix, depth],
+                [include_related, include_related, start_ix, depth],
             ).fetchall()
 
             for row in records:

--- a/backend/main.py
+++ b/backend/main.py
@@ -65,11 +65,11 @@ def version():
 
 @app.get("/graph/{word}")
 @limiter.limit("20/minute")
-def get_graph(request: Request, word: str, depth: int = 5):
+def get_graph(request: Request, word: str, depth: int = 5, include_related: bool = False):
     """Fetch etymology graph for a word."""
     # Clamp depth to reasonable bounds
     depth = max(1, min(depth, 10))
-    graph = fetch_etymology(word, depth=depth)
+    graph = fetch_etymology(word, depth=depth, include_related=include_related)
     if graph is None:
         raise HTTPException(status_code=404, detail="Word not found in the database")
     return graph

--- a/backend/sql/queries/find_start_word.sql
+++ b/backend/sql/queries/find_start_word.sql
@@ -5,6 +5,7 @@ WHERE lower(w.lexeme) = lower(?)
 GROUP BY w.word_ix, w.lang, w.lexeme, w.sense
 ORDER BY
     CASE WHEN w.lang = 'en' THEN 0 ELSE 1 END,
+    SUM(CASE WHEN l.target IS NOT NULL AND (? OR l.type IS NULL OR l.type != 'cog') THEN 1 ELSE 0 END) DESC,
     COUNT(l.target) DESC,
     w.word_ix
 LIMIT 1

--- a/backend/sql/queries/traverse_etymology.sql
+++ b/backend/sql/queries/traverse_etymology.sql
@@ -5,12 +5,14 @@ resolved_links AS (
     SELECT source, target AS parent_ix, FALSE AS is_compound, type
     FROM links
     WHERE target > 0
+      AND (? OR type IS NULL OR type != 'cog')
     UNION ALL
     -- Compound links (negative target = sequence, resolve to parents)
     SELECT l.source, s.parent_ix, TRUE AS is_compound, l.type
     FROM links l
     JOIN sequences s ON s.seq_ix = l.target
     WHERE l.target < 0
+      AND (? OR l.type IS NULL OR l.type != 'cog')
 ),
 traversal(child_ix, parent_ix, is_compound, type, lvl) AS (
     SELECT source, parent_ix, is_compound, type, 1

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -53,6 +53,12 @@ def _prepare_test_database() -> None:
                 (302, "en", "-er", None),  # Morpheme with sense=NULL (garbage links)
                 (303, "en", "garbage1", "unrelated word 1"),  # Garbage target
                 (304, "en", "garbage2", "unrelated word 2"),  # Garbage target
+                # Duplicate selection test: one entry has more cognates, the other has ancestry
+                (400, "en", "sensepick", "cognate-rich entry"),
+                (401, "en", "sensepick", "ancestor-rich entry"),
+                (402, "de", "Sinnwahl", "sensepick cognate 1"),
+                (403, "nl", "zinselectie", "sensepick cognate 2"),
+                (404, "proto-germanic", "sinnakuzaną", "sensepick ancestor"),
             ],
         )
         conn.executemany(
@@ -77,6 +83,11 @@ def _prepare_test_database() -> None:
                 # Garbage links FROM -er (sense=NULL) - should NOT be traversed
                 ("der", 302, 303),  # -er -> garbage1
                 ("der", 302, 304),  # -er -> garbage2
+                # Duplicate selection regression:
+                # entry 400 has more total links but only cognates; entry 401 has ancestry
+                ("cog", 400, 402),
+                ("cog", 400, 403),
+                ("inh", 401, 404),
             ],
         )
 
@@ -225,6 +236,19 @@ def test_graph_can_include_cognates_when_requested():
     lexemes = {n["lexeme"] for n in payload["nodes"]}
     assert "geminus" in lexemes
     assert any(edge["type"] == "cog" for edge in payload["edges"])
+
+
+def test_graph_start_word_selection_matches_related_filter():
+    """Test duplicate ranking uses the same relation filter as traversal."""
+    response = client.get("/graph/sensepick")
+    assert response.status_code == 200
+    payload = response.json()
+
+    lexemes = {n["lexeme"] for n in payload["nodes"]}
+    assert "sinnakuzaną" in lexemes
+    assert "Sinnwahl" not in lexemes
+    assert "zinselectie" not in lexemes
+    assert all(edge["type"] != "cog" for edge in payload["edges"])
 
 
 def test_search_shows_all_valid_senses():

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -197,22 +197,34 @@ def test_random_endpoint_returns_word():
 
 
 def test_graph_picks_entry_with_most_links():
-    """Test that when duplicate entries exist, we pick the one with most etymology links."""
+    """Test that when duplicate entries exist, we pick the richest entry."""
     response = client.get("/graph/twin")
     assert response.status_code == 200
     payload = response.json()
 
     # twin entry 101 has 3 links, entry 100 has 1 link
-    # We should get the richer graph (4 nodes: twin, twinjaz, dwóh₁, geminus)
-    assert len(payload["nodes"]) == 4
-    assert len(payload["edges"]) >= 3
+    # Cognates are hidden by default, so the ancestry graph has 3 nodes.
+    assert len(payload["nodes"]) == 3
+    assert len(payload["edges"]) >= 2
 
     # Verify we have all expected nodes
     lexemes = {n["lexeme"] for n in payload["nodes"]}
     assert "twin" in lexemes
     assert "twinjaz" in lexemes
     assert "dwóh₁" in lexemes
+    assert "geminus" not in lexemes
+    assert all(edge["type"] != "cog" for edge in payload["edges"])
+
+
+def test_graph_can_include_cognates_when_requested():
+    """Test that related/cognate links are opt-in, not part of the default ancestry graph."""
+    response = client.get("/graph/twin?include_related=true")
+    assert response.status_code == 200
+    payload = response.json()
+
+    lexemes = {n["lexeme"] for n in payload["nodes"]}
     assert "geminus" in lexemes
+    assert any(edge["type"] == "cog" for edge in payload["edges"])
 
 
 def test_search_shows_all_valid_senses():

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -51,6 +51,10 @@
                             <input type="checkbox" id="show-link-types">
                             <span>Show link types</span>
                         </label>
+                        <label class="settings-option" title="Show cognates and other related words alongside direct ancestors">
+                            <input type="checkbox" id="include-related">
+                            <span>Include cognates</span>
+                        </label>
                     </div>
                 </div>
                 <!-- Mobile: single menu button -->
@@ -72,6 +76,10 @@
                         <label class="mobile-menu-item settings-option" title="Color edges by link type">
                             <input type="checkbox" id="mobile-show-link-types">
                             <span>Show link types</span>
+                        </label>
+                        <label class="mobile-menu-item settings-option" title="Show cognates and related words">
+                            <input type="checkbox" id="mobile-include-related">
+                            <span>Include cognates</span>
                         </label>
                         <div class="mobile-menu-divider"></div>
                         <a href="https://github.com/lucharo/etymology-for-all/issues/new/choose" target="_blank" rel="noopener" class="mobile-menu-item mobile-external-link">Report an issue <span class="external-icon">↗</span></a>
@@ -361,8 +369,8 @@
                     </p>
                     <h3>Graph Traversal</h3>
                     <p>
-                        The graph follows etymology connections recursively up to 5 levels deep,
-                        including both ancestors and cognates.
+                        The graph follows etymology connections recursively up to 5 levels deep.
+                        It shows direct ancestors by default; cognates can be included from settings.
                     </p>
                     <p class="example">
                         Example: "friend" connects to 12 words directly. Following each of those
@@ -414,7 +422,7 @@
                     </ol>
                     <h3>Reading the Graph</h3>
                     <ul>
-                        <li><strong>Arrows</strong> point from modern words to their ancestors</li>
+                        <li><strong>Arrows</strong> point from modern words to their ancestors by default</li>
                         <li><strong>Click any word</strong> to see its language family and definition</li>
                         <li><strong>Language families</strong> show how languages are historically related</li>
                     </ul>
@@ -433,9 +441,10 @@
                     <h3>Limitations</h3>
                     <p>
                         Not all words have definitions available. Some etymology connections may be incomplete
-                        or reflect Wiktionary's editorial choices. Compound word breakdowns (e.g., "magn-animus")
-                        are not yet supported. Definition matching between EtymDB senses and dictionary entries
-                        is approximate—there is no shared identifier between the two data sources.
+                        or reflect Wiktionary's editorial choices. Cognates are related words, not direct
+                        ancestors, so they are hidden by default and can be enabled separately. Definition
+                        matching between EtymDB senses and dictionary entries is approximate—there is no shared
+                        identifier between the two data sources.
                     </p>
                 </div>
             </div>

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -42,6 +42,7 @@ const elements = {
     searchBtn: document.getElementById('search-btn'),
     randomBtn: document.getElementById('random-btn'),
     includeCompound: document.getElementById('include-compound'),
+    includeRelated: document.getElementById('include-related'),
     graphContainer: document.getElementById('graph-container'),
     cyContainer: document.getElementById('cy'),
     loadingEl: document.getElementById('loading'),
@@ -87,6 +88,11 @@ let searchTimeout = null;
 let serverReady = false;
 let graphAvailable = false;
 let currentView = 'graph'; // 'graph' or 'tree'
+let currentIncludeRelated = false;
+
+function shouldIncludeRelated() {
+    return elements.includeRelated?.checked ?? false;
+}
 
 // Server health check with retry (HF Spaces sleep after inactivity)
 async function checkServerHealth(maxWaitMs = 120000) {
@@ -226,9 +232,16 @@ function renderGraph(data, searchedWord, filterByDepth = true) {
         return;
     }
 
-    if (!filterByDepth || !fullGraphData || currentSearchedWord !== searchedWord) {
+    const includeRelated = shouldIncludeRelated();
+    if (
+        !filterByDepth ||
+        !fullGraphData ||
+        currentSearchedWord !== searchedWord ||
+        currentIncludeRelated !== includeRelated
+    ) {
         fullGraphData = data;
         currentSearchedWord = searchedWord;
+        currentIncludeRelated = includeRelated;
         graphMaxDepth = calculateMaxGraphDepth(data.nodes, data.edges, searchedWord);
         currentDepth = graphMaxDepth;
     }
@@ -288,7 +301,7 @@ async function handleSearch() {
     showLoading(elements);
 
     try {
-        const data = await fetchEtymology(word);
+        const data = await fetchEtymology(word, shouldIncludeRelated());
         renderGraph(data, word);
     } catch (err) {
         showError(err.message, elements, minimizeGraph, { searchedWord: word });
@@ -312,7 +325,7 @@ async function handleRandom() {
             return;
         }
         elements.wordInput.value = word;
-        const data = await fetchEtymology(word);
+        const data = await fetchEtymology(word, shouldIncludeRelated());
         renderGraph(data, word);
     } catch (err) {
         showError(err.message, elements, minimizeGraph, { searchedWord: elements.wordInput.value.trim() });
@@ -397,6 +410,23 @@ document.addEventListener('DOMContentLoaded', async () => {
             if (mobileCompound) mobileCompound.checked = elements.includeCompound.checked;
             if (fullGraphData && currentSearchedWord) {
                 renderGraph(fullGraphData, currentSearchedWord, true);
+            }
+        });
+    }
+
+    // Related-word filter checkbox - re-fetches because cognates are excluded server-side by default
+    if (elements.includeRelated) {
+        elements.includeRelated.addEventListener('change', async () => {
+            const mobileRelated = document.getElementById('mobile-include-related');
+            if (mobileRelated) mobileRelated.checked = elements.includeRelated.checked;
+            if (currentSearchedWord) {
+                showLoading(elements);
+                try {
+                    const data = await fetchEtymology(currentSearchedWord, shouldIncludeRelated());
+                    renderGraph(data, currentSearchedWord);
+                } catch (err) {
+                    showError(err.message, elements, minimizeGraph, { searchedWord: currentSearchedWord });
+                }
             }
         });
     }
@@ -561,6 +591,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     const mobileMenu = document.getElementById('mobile-menu');
     const mobileAboutBtn = document.getElementById('mobile-about-btn');
     const mobileIncludeCompound = document.getElementById('mobile-include-compound');
+    const mobileIncludeRelated = document.getElementById('mobile-include-related');
 
     if (mobileMenuBtn && mobileMenu) {
         mobileMenuBtn.addEventListener('click', (e) => {
@@ -586,6 +617,14 @@ document.addEventListener('DOMContentLoaded', async () => {
         mobileIncludeCompound.addEventListener('change', () => {
             elements.includeCompound.checked = mobileIncludeCompound.checked;
             elements.includeCompound.dispatchEvent(new Event('change'));
+        });
+    }
+
+    // Sync mobile related checkbox with desktop
+    if (mobileIncludeRelated && elements.includeRelated) {
+        mobileIncludeRelated.addEventListener('change', () => {
+            elements.includeRelated.checked = mobileIncludeRelated.checked;
+            elements.includeRelated.dispatchEvent(new Event('change'));
         });
     }
 

--- a/frontend/js/search.js
+++ b/frontend/js/search.js
@@ -6,8 +6,12 @@ import { handleApiResponse, truncate, escapeHtml } from './utils.js';
 
 const FETCH_DEPTH = 10;
 
-export async function fetchEtymology(word) {
-    const response = await fetch(`/graph/${encodeURIComponent(word)}?depth=${FETCH_DEPTH}`);
+export async function fetchEtymology(word, includeRelated = false) {
+    const params = new URLSearchParams({
+        depth: FETCH_DEPTH,
+        include_related: includeRelated,
+    });
+    const response = await fetch(`/graph/${encodeURIComponent(word)}?${params.toString()}`);
     await handleApiResponse(response, 'etymology lookup');
     const data = await response.json();
     return data;


### PR DESCRIPTION
## Summary

- Hide cognate (`cog`) links from default etymology graphs so arrows represent direct ancestry.
- Add `include_related=true` plus desktop/mobile “Include cognates” controls to opt into related-word graphs.
- Make duplicate start-word ranking use the same cognate filter as traversal, with regression coverage.

## Why

Clémentine Fourrier pointed out that examples like “cat” were mixing cognates with parent/ancestor relationships. The database already exposes link types, but the app was traversing and displaying all of them as ancestry by default.

## Validation

- `uv run pytest backend/tests -q`
- `uv run ruff check .`
- `git diff --check`
- `roborev fix --open --list` reported no open jobs after the follow-up fix.
